### PR TITLE
Use finalizedBy to hook transformations after javaCompile

### DIFF
--- a/morpheus-plugin/src/main/groovy/com/github/stephanenicolas/morpheus/AbstractMorpheusPlugin.groovy
+++ b/morpheus-plugin/src/main/groovy/com/github/stephanenicolas/morpheus/AbstractMorpheusPlugin.groovy
@@ -50,18 +50,16 @@ public abstract class AbstractMorpheusPlugin implements Plugin<Project> {
     def hasLib = project.plugins.withType(LibraryPlugin)
     ensureProjectIsAndroidAppOrLib(hasApp, hasLib)
 
-    final def variants
-    if (hasApp) {
-      variants = project.android.applicationVariants
-    } else {
-      variants = project.android.libraryVariants
-    }
-
     configure(project)
 
-    variants.all { variant ->
-      applyVariant(project, variant)
+    if (hasApp) {
+      project.android.applicationVariants.all { variant -> applyVariant(project, variant) }
     }
+    if (hasLib) {
+      project.android.libraryVariants.all { variant -> applyVariant(project, variant) }
+    }
+    project.android.testVariants.all { variant -> applyVariant(project, variant) }
+    project.android.unitTestVariants.all { variant -> applyVariant(project, variant) }
   }
 
   public void applyVariant(Project project, BaseVariant variant) {

--- a/morpheus-plugin/src/main/groovy/com/github/stephanenicolas/morpheus/AbstractMorpheusPlugin.groovy
+++ b/morpheus-plugin/src/main/groovy/com/github/stephanenicolas/morpheus/AbstractMorpheusPlugin.groovy
@@ -120,7 +120,9 @@ public abstract class AbstractMorpheusPlugin implements Plugin<Project> {
    * Can be null, then no extension is created.
    * @see #getExtension()
    */
-  protected abstract Class getPluginExtension()
+  protected Class getPluginExtension() {
+    return null
+  }
 
   /**
    * @return the extension of the project that this plugin can create.
@@ -128,7 +130,9 @@ public abstract class AbstractMorpheusPlugin implements Plugin<Project> {
    * Can be null, then no extension is created.
    * @see #getPluginExtension()
    */
-  protected abstract String getExtension()
+  protected String getExtension() {
+    return null
+  }
 
   /**
    * A list of transformer instances to be used during build.

--- a/morpheus-plugin/src/main/groovy/com/github/stephanenicolas/morpheus/AbstractMorpheusPlugin.groovy
+++ b/morpheus-plugin/src/main/groovy/com/github/stephanenicolas/morpheus/AbstractMorpheusPlugin.groovy
@@ -33,15 +33,23 @@ import org.gradle.api.tasks.compile.JavaCompile
 public abstract class AbstractMorpheusPlugin implements Plugin<Project> {
   @Override
   public void apply(Project project) {
-    def hasApp = project.plugins.withType(AppPlugin)
-    def hasLib = project.plugins.withType(LibraryPlugin)
-    ensureProjectIsAndroidAppOrLib(hasApp, hasLib)
-
     def extension = getExtension()
     def pluginExtension = getPluginExtension()
     if (extension && pluginExtension) {
       project.extensions.create(extension, pluginExtension)
     }
+
+    // Variants might not have been created 
+    // until the project has been evaluated
+    project.afterEvaluate {
+      applyAfterEvaluated(project)
+    }
+  }
+
+  public void applyAfterEvaluated(Project project) {
+    def hasApp = project.plugins.withType(AppPlugin)
+    def hasLib = project.plugins.withType(LibraryPlugin)
+    ensureProjectIsAndroidAppOrLib(hasApp, hasLib)
 
     final def log = project.logger
     final String LOG_TAG = this.getClass().getName()


### PR DESCRIPTION
## Use finalizedBy to hook transformations after javaCompile  …
I've noticed that the transformations weren't being applied to my AndroidLibrary, since it's `assemble` task was never called.

Instead of finding the task that depended on compile, javaCompile.finalizedBy turned out to be a better solution

## Default implementation for AbstractMorpheusPlugin.getPluginExtension
Returns null because I`m lazy

## Wait until project has been fully evaluated before hooking the variants
Otherwise variants = []

## Move per-variant code into applyJavaCompile 
Because I need an entry point to hack the JavaCompile object to use a custom `android.jar`